### PR TITLE
[Issue-11] Replaces yaml.load with yaml.full_load

### DIFF
--- a/frontmatter/__init__.py
+++ b/frontmatter/__init__.py
@@ -34,7 +34,7 @@ class Frontmatter:
             fmatter = result.group(1)
             body = result.group(2)
         return {
-            "attributes": yaml.load(fmatter, Loader=yaml.FullLoader),
+            "attributes": yaml.full_load(fmatter),
             "body": body,
             "frontmatter": fmatter,
         }


### PR DESCRIPTION
### Description

Fixes deprecation warning for `yaml.load`.

If there is anything else I can do to help get this PR accepted and a new release published, please let me know.

### Techincal Description

Whilst using `frontmatter==3.0.7` in my project, the following deprecation warning was produced

```
  /usr/local/lib/python3.9/site-packages/frontmatter/__init__.py:37: YAMLLoadWarning: calling yaml.load() without Loader=... is deprecated, as the default Loader is unsafe. Please read https://msg.pyyaml.org/load for full details.
    "attributes": yaml.load(fmatter),
```

After reviewing master, this is the offending line in [frontmatter](https://github.com/jonbeebe/frontmatter/blob/accd644b15a5ac7adaab261655eb552065020821/frontmatter/__init__.py#L37


According to the documentation at https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation, this should be replaced with the following from PyYAML 5.1+ which is already [included](https://github.com/jonbeebe/frontmatter/blob/master/requirements.txt#L2) as a dependency: 

```python
        "attributes": yaml.full_load(fmatter),
```

Fixes https://github.com/jonbeebe/frontmatter/issues/11

### Test Output

```bash
$ ./run_tests.bash

[attributes]
{'title': 'Third Post', 'date': 'Oct 8, 2018 5:26pm PST'}

[body]
This is my third post with a blockquote and footnote[^1]:

> This is what someone said.

---

This is a [link to this post]({{ ref "2018/09/first-post" }}) and [another link]({{ ref "2018/09/first-post" }}).

---

[^1]: This would be a footnote with a [link to first post]({{ ref "2018/09/first-post" }}).



[frontmatter]

title: Third Post
date: Oct 8, 2018 5:26pm PST

TEST SUCCEEDED.
```

